### PR TITLE
Add Continuous Integration by GitHub Actions

### DIFF
--- a/.github/workflows/check_build.yaml
+++ b/.github/workflows/check_build.yaml
@@ -18,6 +18,9 @@ jobs:
           cp Make.gcc_mvapich2 Make.gcc_openmpi
           cd ..
 
+      - name: configure
+        run: ./configure gcc_openmpi
+
       - name: make
         run: make
 

--- a/.github/workflows/check_build.yaml
+++ b/.github/workflows/check_build.yaml
@@ -24,3 +24,6 @@ jobs:
       - name: make
         run: make
 
+      - name: Run the program without arguments
+        run: ./build_gcc_openmpi/gmrm || true
+

--- a/.github/workflows/check_build.yaml
+++ b/.github/workflows/check_build.yaml
@@ -1,0 +1,23 @@
+# This script checks if the code can be compiled
+
+on:
+  push:
+  pull_request:
+
+name: check_build
+
+jobs:
+  check_build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: First step, from the Wiki
+        run: |
+          cd setup/
+          cp Make.gcc_mvapich2 Make.gcc_openmpi
+          cd ..
+
+      - name: make
+        run: make
+

--- a/.github/workflows/check_build.yaml
+++ b/.github/workflows/check_build.yaml
@@ -12,16 +12,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install OpenMPI
+        run: sudo apt install libopenmpi-dev
+
       - name: First step, from the Wiki
         run: |
           cd setup/
           cp Make.gcc_mvapich2 Make.gcc_openmpi
           cd ..
 
-      - name: configure
+      - name: Configure
         run: ./configure gcc_openmpi
 
-      - name: make
+      - name: Make
         run: make
 
       - name: Run the program without arguments

--- a/.github/workflows/check_build.yaml
+++ b/.github/workflows/check_build.yaml
@@ -15,6 +15,9 @@ jobs:
       - name: Install OpenMPI
         run: sudo apt install libopenmpi-dev
 
+      - name: Install Boost
+        run: sudo apt install libboost-all-dev
+
       - name: First step, from the Wiki
         run: |
           cd setup/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 bin/
 build_*/
 dataset/
+Makefile

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # gmrm
 
+Branch   |Status
+---------|-------------------------------------------------------------------------------------------------------------
+`main`   |![check_build](https://github.com/medical-genomics-group/gmrm/workflows/check_build/badge.svg?branch=main)   
+`effects`|![check_build](https://github.com/medical-genomics-group/gmrm/workflows/check_build/badge.svg?branch=effects)
+
 Welcome to the home of our `gmrm` software. The code is hybrid-parallel software for a Bayesian grouped mixture of regressions model for genome-wide association studies (GWAS). It is written in C++ using extensive optimisations and code vectorisation. It relies on plink's .bed format. It can analyse multiple traits simultaneously.
 
 For an overview, help with compilation, and a documented workflow example please see our wiki: 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Branch   |Status
 ---------|-------------------------------------------------------------------------------------------------------------
-`main`   |![check_build](https://github.com/medical-genomics-group/gmrm/workflows/check_build/badge.svg?branch=main)   
-`effects`|![check_build](https://github.com/medical-genomics-group/gmrm/workflows/check_build/badge.svg?branch=effects)
+`main`   |![check_build](https://github.com/richelbilderbeek/gmrm/workflows/check_build/badge.svg?branch=main)   
+`effects`|![check_build](https://github.com/richelbilderbeek/gmrm/workflows/check_build/badge.svg?branch=effects)
 
 Welcome to the home of our `gmrm` software. The code is hybrid-parallel software for a Bayesian grouped mixture of regressions model for genome-wide association studies (GWAS). It is written in C++ using extensive optimisations and code vectorisation. It relies on plink's .bed format. It can analyse multiple traits simultaneously.
 

--- a/setup/.gitignore
+++ b/setup/.gitignore
@@ -1,0 +1,1 @@
+Make.gcc_openmpi


### PR DESCRIPTION
Dear @ctggroup, hi Matthew,

As promised, I created a GitHub Actions script that compiles `gmrm`, and gives an error when this fails. You can see the action at [my Fork](https://github.com/richelbilderbeek/gmrm/actions/runs/2331585678). After accepting this PR, this will be shown at the 'Actions' tab of this repo.

I volunteer to maintain the GitHub Actions script.

The status badge in the README.md is pointed to the `richelbilderbeek` fork so one can see how this looks. Replace `richelbilderbeek` by `medical-genomics-group` and the status badge will display the build status of this repo.

I refrained from adding much more, such as below, but I'd volunteer to add these as well:
 * running the code on some test data, 
 * run the test (which are absent for now)
 * measuring code coverage
 * measuring a run-time speed profile
 * adding a style check

If one likes to chat about Continuous Integration, I'd be happy to schedule a meeting.

Hope you like it! If not, feel free to let me change things and/or decline :-)

Cheers, Richel